### PR TITLE
grand access to other model URLs, not just CSCS

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -11,6 +11,5 @@ jobs:
           docker login ${{secrets.EBRAINS_REGISTRY_SERVER}} -u ${{ secrets.DOCKER_REGISTRY_USER }} -p ${{secrets.DOCKER_REGISTRY_PASSWORD}}
       - name: build and publish frontend and backend
         run: |
-          make build
           make publish
           

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,16 @@
+name: Publish frontend/backend images to Ebrains Docker Registry
+on:
+  [workflow_dispatch]
+
+jobs:
+  publish_images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: log in
+        run: |
+          docker login ${{secrets.EBRAINS_REGISTRY_SERVER}} -u ${{ secrets.DOCKER_REGISTRY_USER }} -p ${{secrets.DOCKER_REGISTRY_PASSWORD}}
+      - name: build and publish frontend and backend
+        run: |
+          make build
+          make publish
+          

--- a/backend/blue_naas/main.py
+++ b/backend/blue_naas/main.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from random import choice
 from string import ascii_uppercase
-from urllib.parse import urlunsplit
+from urllib.parse import urlunsplit, urlparse
 from zipfile import ZipFile
 
 import requests
@@ -26,11 +26,14 @@ CELL = None
 
 def _load_from_url(url):
     try:
-        zip_url = urlunsplit(('https',
-                              'object.cscs.ch',
-                              'v1/AUTH_c0a333ecf7c045809321ce9d9ecdfdea/' + url,
-                              None,
-                              None))
+        if urlparse(url).scheme:
+            zip_url = url
+        else:
+            zip_url = urlunsplit(('https',
+                                  'object.cscs.ch',
+                                  'v1/AUTH_c0a333ecf7c045809321ce9d9ecdfdea/' + url,
+                                  None,
+                                  None))
         L.debug('downloading emodel from url: %s', zip_url)
         response = requests.get(zip_url, stream=True, timeout=10)
         try:


### PR DESCRIPTION
In _EBRAINS 2.0_ project and in the usage of _Ebrains Live Papers_ the URLs for downloading emodels can differ(the AUTH key from URL can be different). For now just a simple check was added - to download the emodel if an absolute url is given. For the future a set of URLs for validation can be taken into consideration.